### PR TITLE
Add a simple spec for validating presence of an _order field.

### DIFF
--- a/spec/activerecord-validation/presence_validation_spec.rb
+++ b/spec/activerecord-validation/presence_validation_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Musician do
+  context 'when model has a validation on the order column' do
+    before(:all) do
+      Musician.validates :performance_order, :presence => true
+    end
+
+    it 'creates instances without error' do
+      musician = Musician.create(:name => 'The Beatles')
+      expect(musician).to have(0).errors
+    end
+  end
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :city
     t.integer :score
   end
+
+  create_table :musicians, :force => true do |t|
+    t.string :name
+    t.integer :performance_order
+  end
 end
 
 class Duck < ActiveRecord::Base
@@ -139,4 +144,9 @@ end
 
 class Player < ActiveRecord::Base
   # don't add rank yet, do it in the specs
+end
+
+class Musician < ActiveRecord::Base
+  include RankedModel
+  ranks :performance_order
 end


### PR DESCRIPTION
This is the same issue as #51, but I've added a breaking test.

Basically, `before_save :handle_ranking` gets run only **after** the validation throws the error. This is because validation callbacks happen first:

![screen shot 2014-03-02 at 11 59 47 pm](https://f.cloud.github.com/assets/590450/2306684/ab21aa0c-a290-11e3-8eff-4635559130b1.png)
