### PR TITLE
Handle ranking before validation

### DIFF
--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -15,7 +15,7 @@ module RankedModel
 
       extend RankedModel::ClassMethods
 
-      before_save :handle_ranking
+      before_validation :handle_ranking
 
       scope :rank, lambda { |name|
         order ranker(name.to_sym).column

--- a/spec/activerecord-validation/presence_validation_spec.rb
+++ b/spec/activerecord-validation/presence_validation_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Musician do
+  context 'when model has a validation on the order column' do
+    before(:all) do
+      Musician.validates :performance_order, :presence => true
+    end
+
+    it 'creates instances without error' do
+      musician = Musician.create(:name => 'The Beatles')
+      expect(musician).to have(0).errors
+    end
+  end
+end

--- a/spec/duck-model/duck_spec.rb
+++ b/spec/duck-model/duck_spec.rb
@@ -44,9 +44,9 @@ describe Duck do
     }
     @ducks.each { |name, duck|
       duck.reload
-      duck.update_attribute :row_position, 0
-      duck.update_attribute :size_position, 0
-      duck.update_attribute :age_position, 0
+      duck.update_attributes(:row_position => 0)
+      duck.update_attributes(:size_position => 0)
+      duck.update_attributes(:age_position => 0)
       duck.save!
     }
     @ducks.each {|name, duck| duck.reload }
@@ -55,8 +55,8 @@ describe Duck do
   describe "sorting by size on in_shin_pond" do
 
     before {
-      @ducks[:quacky].update_attribute :size_position, 0
-      @ducks[:wingy].update_attribute :size_position, 2
+      @ducks[:quacky].update_attributes(:size_position => 0)
+      @ducks[:wingy].update_attributes(:size_position => 2)
     }
 
     subject { Duck.in_shin_pond.rank(:size).to_a }
@@ -72,8 +72,8 @@ describe Duck do
   describe "sorting by age on Shin pond" do
 
     before {
-      @ducks[:feathers].update_attribute :age_position, 0
-      @ducks[:wingy].update_attribute :age_position, 0
+      @ducks[:feathers].update_attributes(:age_position => 0)
+      @ducks[:wingy].update_attributes(:age_position => 0)
     }
 
     subject { Duck.where(:pond => 'Shin').rank(:age).to_a }
@@ -89,10 +89,10 @@ describe Duck do
   describe "sorting by row" do
 
     before {
-      @ducks[:beaky].update_attribute :row_position, 0
-      @ducks[:webby].update_attribute :row_position, 2
-      @ducks[:waddly].update_attribute :row_position, 2
-      @ducks[:wingy].update_attribute :row_position, 6
+      @ducks[:beaky].update_attributes(:row_position => 0)
+      @ducks[:webby].update_attributes(:row_position => 2)
+      @ducks[:waddly].update_attributes(:row_position => 2)
+      @ducks[:wingy].update_attributes(:row_position => 6)
     }
 
     subject { Duck.rank(:row).to_a }
@@ -108,13 +108,13 @@ describe Duck do
   describe "mixed sorting by" do
 
     before {
-      @ducks[:quacky].update_attribute :size_position, 0
-      @ducks[:beaky].update_attribute :row_position, 0
-      @ducks[:webby].update_attribute :row_position, 2
-      @ducks[:wingy].update_attribute :size_position, 1
-      @ducks[:waddly].update_attribute :row_position, 2
-      @ducks[:wingy].update_attribute :row_position, 6
-      @ducks[:webby].update_attribute :row_position, 6
+      @ducks[:quacky].update_attributes(:size_position => 0)
+      @ducks[:beaky].update_attributes(:row_position => 0)
+      @ducks[:webby].update_attributes(:row_position => 2)
+      @ducks[:wingy].update_attributes(:size_position => 1)
+      @ducks[:waddly].update_attributes(:row_position => 2)
+      @ducks[:wingy].update_attributes(:row_position => 6)
+      @ducks[:webby].update_attributes(:row_position => 6)
     }
 
     describe "row" do
@@ -149,7 +149,7 @@ describe Duck do
       # puts Duck.rank(:age).collect {|duck| "#{duck.name} #{duck.age}" }
       duck = Duck.rank(:age)[2]
       ->{
-        duck.update_attribute :name, 'New Name'
+        duck.update_attributes(:name => 'New Name')
       }.should_not change(duck.reload, :age)
       # puts Duck.rank(:age).collect {|duck| "#{duck.name} #{duck.age}" }
     end
@@ -183,7 +183,7 @@ describe Duck do
 
       before {
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect {|duck| duck.id }
-        @ducks[:wingy].update_attribute :row_position, 2
+        @ducks[:wingy].update_attributes(:row_position => 2)
       }
 
       context {
@@ -210,7 +210,7 @@ describe Duck do
 
       before {
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect {|duck| duck.id }
-        @ducks[:wingy].update_attribute :row_position, 0
+        @ducks[:wingy].update_attributes(:row_position => 0)
       }
 
       context {
@@ -243,7 +243,7 @@ describe Duck do
 
       before {
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect {|duck| duck.id }
-        @ducks[:wingy].update_attribute :row_position, (@ducks.size - 1)
+        @ducks[:wingy].update_attributes(:row_position => (@ducks.size - 1))
       }
 
       context {
@@ -284,7 +284,7 @@ describe Duck do
 
       before {
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect {|duck| duck.id }
-        @ducks[:wingy].update_attribute :row_position, :last
+        @ducks[:wingy].update_attributes(:row_position => :last)
       }
 
       context {
@@ -325,7 +325,7 @@ describe Duck do
 
       before {
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect {|duck| duck.id }
-        @ducks[:wingy].update_attribute :row_position, 'last'
+        @ducks[:wingy].update_attributes(:row_position => 'last')
       }
 
       context {
@@ -368,7 +368,7 @@ describe Duck do
 
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect { |duck| duck.id }
-          @ducks[:wingy].update_attribute :row_position, :down
+          @ducks[:wingy].update_attributes(:row_position => :down)
         }
 
         context {
@@ -395,7 +395,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:quacky].id).collect { |duck| duck.id }
-          @ducks[:quacky].update_attribute :row_position, :down
+          @ducks[:quacky].update_attributes(:row_position => :down)
         }
 
         context {
@@ -420,7 +420,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:feathers].id).collect { |duck| duck.id }
-          @ducks[:feathers].update_attribute :row_position, :down
+          @ducks[:feathers].update_attributes(:row_position => :down)
         }
 
         context {
@@ -449,7 +449,7 @@ describe Duck do
 
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect { |duck| duck.id }
-          @ducks[:wingy].update_attribute :row_position, 'down'
+          @ducks[:wingy].update_attributes(:row_position => 'down')
         }
 
         context {
@@ -476,7 +476,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:quacky].id).collect { |duck| duck.id }
-          @ducks[:quacky].update_attribute :row_position, 'down'
+          @ducks[:quacky].update_attributes(:row_position => 'down')
         }
 
         context {
@@ -501,7 +501,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:feathers].id).collect { |duck| duck.id }
-          @ducks[:feathers].update_attribute :row_position, 'down'
+          @ducks[:feathers].update_attributes(:row_position => 'down')
         }
 
         context {
@@ -530,7 +530,7 @@ describe Duck do
 
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect { |duck| duck.id }
-          @ducks[:wingy].update_attribute :row_position, :up
+          @ducks[:wingy].update_attributes(:row_position => :up)
         }
 
         context {
@@ -557,7 +557,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:beaky].id).collect { |duck| duck.id }
-          @ducks[:beaky].update_attribute :row_position, :up
+          @ducks[:beaky].update_attributes(:row_position => :up)
         }
 
         context {
@@ -582,7 +582,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:waddly].id).collect { |duck| duck.id }
-          @ducks[:waddly].update_attribute :row_position, :up
+          @ducks[:waddly].update_attributes(:row_position => :up)
         }
 
         context {
@@ -611,7 +611,7 @@ describe Duck do
 
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:wingy].id).collect { |duck| duck.id }
-          @ducks[:wingy].update_attribute :row_position, 'up'
+          @ducks[:wingy].update_attributes(:row_position => 'up')
         }
 
         context {
@@ -638,7 +638,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:beaky].id).collect { |duck| duck.id }
-          @ducks[:beaky].update_attribute :row_position, 'up'
+          @ducks[:beaky].update_attributes(:row_position => 'up')
         }
 
         context {
@@ -663,7 +663,7 @@ describe Duck do
         
         before {
           @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_eq @ducks[:waddly].id).collect { |duck| duck.id }
-          @ducks[:waddly].update_attribute :row_position, 'up'
+          @ducks[:waddly].update_attributes(:row_position => 'up')
         }
 
         context {
@@ -721,7 +721,7 @@ describe Duck do
     }
     @ducks.each { |name, duck|
       duck.reload
-      duck.update_attribute :landing_order_position, 0
+      duck.update_attributes(:landing_order_position => 0)
       duck.save!
     }
     @ducks.each {|name, duck| duck.reload }
@@ -730,8 +730,8 @@ describe Duck do
   describe "sorting by landing_order" do
 
     before {
-      @ducks[:quacky].update_attribute :landing_order_position, 0
-      @ducks[:wingy].update_attribute :landing_order_position, 1
+      @ducks[:quacky].update_attributes(:landing_order_position => 0)
+      @ducks[:wingy].update_attributes(:landing_order_position => 1)
     }
 
     subject { Duck.in_lake_and_flock(0,0).rank(:landing_order).to_a }
@@ -755,10 +755,10 @@ describe Duck do
 
       @previous_ranks = @untouchable_ranks.call
 
-      @ducks[:quacky].update_attribute :landing_order_position, 0
-      @ducks[:wingy].update_attribute :landing_order_position, 1
-      @ducks[:feathers].update_attribute :landing_order_position, 0
-      @ducks[:wingy].update_attribute :landing_order_position, 1
+      @ducks[:quacky].update_attributes(:landing_order_position => 0)
+      @ducks[:wingy].update_attributes(:landing_order_position => 1)
+      @ducks[:feathers].update_attributes(:landing_order_position => 0)
+      @ducks[:wingy].update_attributes(:landing_order_position => 1)
     }
 
     subject { @untouchable_ranks.call }

--- a/spec/duck-model/lots_of_ducks_spec.rb
+++ b/spec/duck-model/lots_of_ducks_spec.rb
@@ -15,7 +15,7 @@ describe Duck do
 
       before {
         @last = Duck.last
-        @last.update_attribute :row_position, 137
+        @last.update_attributes(:row_position => 137)
       }
 
       subject { Duck.ranker(:row).with(Duck.new).current_at_position(137).instance }
@@ -28,7 +28,7 @@ describe Duck do
 
       before {
         @last = Duck.last
-        @last.update_attribute :row_position, 2
+        @last.update_attributes(:row_position => 2)
       }
 
       subject { Duck.ranker(:row).with(Duck.new).current_at_position(2).instance }
@@ -41,7 +41,7 @@ describe Duck do
 
       before {
         @last = Duck.last
-        @last.update_attribute :row_position, :last
+        @last.update_attributes(:row_position => :last)
       }
 
       subject { Duck.rank(:row).last }
@@ -54,7 +54,7 @@ describe Duck do
 
       before {
         @last = Duck.last
-        @last.update_attribute :row_position, :first
+        @last.update_attributes(:row_position => :first)
       }
 
       subject { Duck.rank(:row).first }
@@ -73,8 +73,8 @@ describe Duck do
         @first = Duck.first
         @second = Duck.offset(1).first
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_in([@first.id, @second.id])).collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MAX_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE
+        @first.update_attributes(:row => RankedModel::MAX_RANK_VALUE)
+        @second.update_attributes(:row => RankedModel::MAX_RANK_VALUE)
       }
 
       context {
@@ -96,8 +96,8 @@ describe Duck do
         @duck_11 = Duck.offset(10).first
         @duck_12 = Duck.offset(11).first
         @ordered = Duck.where(:pond => 'Pond 1').rank(:age).where(Duck.arel_table[:id].not_in([@duck_11.id, @duck_12.id])).collect {|d| d.id }
-        @duck_11.update_attribute :age, RankedModel::MAX_RANK_VALUE
-        @duck_12.update_attribute :age, RankedModel::MAX_RANK_VALUE
+        @duck_11.update_attributes(:age => RankedModel::MAX_RANK_VALUE)
+        @duck_12.update_attributes(:age => RankedModel::MAX_RANK_VALUE)
       }
 
       context {
@@ -119,8 +119,8 @@ describe Duck do
         @first = Duck.first
         @second = Duck.offset(1).first
         @ordered = Duck.rank(:row).where(Duck.arel_table[:id].not_in([@first.id, @second.id])).collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MIN_RANK_VALUE
+        @first.update_attributes(:row => RankedModel::MIN_RANK_VALUE)
+        @second.update_attributes(:row => RankedModel::MIN_RANK_VALUE)
       }
 
       context {
@@ -148,10 +148,10 @@ describe Duck do
           where(Duck.arel_table[:id].not_in([@first.id, @second.id, @third.id, @fourth.id])).
           where(Duck.arel_table[:row].gteq(RankedModel::MAX_RANK_VALUE / 2)).
           collect {|d| d.id }
-        @first.update_attribute :row, RankedModel::MIN_RANK_VALUE
-        @second.update_attribute :row, RankedModel::MAX_RANK_VALUE
-        @third.update_attribute :row, (RankedModel::MAX_RANK_VALUE / 2)
-        @fourth.update_attribute :row, @third.row
+        @first.update_attributes(:row => RankedModel::MIN_RANK_VALUE)
+        @second.update_attributes(:row => RankedModel::MAX_RANK_VALUE)
+        @third.update_attributes(:row => (RankedModel::MAX_RANK_VALUE / 2))
+        @fourth.update_attributes(:row => @third.row)
       }
 
       context {

--- a/spec/ego-model/ego_spec.rb
+++ b/spec/ego-model/ego_spec.rb
@@ -10,7 +10,7 @@ describe Ego do
     }
     @egos.each { |name, ego|
       ego.reload
-      ego.update_attribute :size_position, 0
+      ego.update_attributes(:size_position => 0)
       ego.save!
     }
     @egos.each {|name, ego| ego.reload }
@@ -19,8 +19,8 @@ describe Ego do
   describe "sorting on size alternative primary key" do
 
     before {
-      @egos[:nick].update_attribute :size_position, 0
-      @egos[:sally].update_attribute :size_position, 2
+      @egos[:nick].update_attributes(:size_position => 0)
+      @egos[:sally].update_attributes(:size_position => 2)
     }
 
     subject { Ego.rank(:size).to_a }

--- a/spec/sti-model/element_spec.rb
+++ b/spec/sti-model/element_spec.rb
@@ -12,7 +12,7 @@ describe Element do
     }
     @elements.each { |name, element|
       element.reload
-      element.update_attribute :combination_order_position, 0
+      element.update_attributes(:combination_order_position => 0)
     }
     @elements.each {|name, element| element.reload }
   }
@@ -20,9 +20,9 @@ describe Element do
   describe "rebalancing on an STI class should not affect the other class" do
 
     before {
-      @elements[:helium].update_attribute :combination_order_position, :first
-      @elements[:xenon].update_attribute :combination_order_position, :first
-      @elements[:argon].update_attribute :combination_order_position, :last
+      @elements[:helium].update_attributes(:combination_order_position => :first)
+      @elements[:xenon].update_attributes(:combination_order_position => :first)
+      @elements[:argon].update_attributes(:combination_order_position => :last)
 
       TransitionMetal.ranker(:combination_order).with(@elements[:chromium]).instance_eval { rebalance_ranks }
     }
@@ -40,16 +40,16 @@ describe Element do
   describe "setting positions on STI classes" do
 
     before {
-      @elements[:helium].update_attribute :combination_order_position, :first
-      @elements[:xenon].update_attribute :combination_order_position, :first
-      @elements[:argon].update_attribute :combination_order_position, :first
+      @elements[:helium].update_attributes(:combination_order_position => :first)
+      @elements[:xenon].update_attributes(:combination_order_position => :first)
+      @elements[:argon].update_attributes(:combination_order_position => :first)
 
-      @elements[:chromium].update_attribute :combination_order_position, 1
-      @elements[:manganese].update_attribute :combination_order_position, 1
-      @elements[:manganese].update_attribute :combination_order_position, 0
-      @elements[:chromium].update_attribute :combination_order_position, 0
-      @elements[:manganese].update_attribute :combination_order_position, 0
-      @elements[:chromium].update_attribute :combination_order_position, 0
+      @elements[:chromium].update_attributes(:combination_order_position => 1)
+      @elements[:manganese].update_attributes(:combination_order_position => 1)
+      @elements[:manganese].update_attributes(:combination_order_position => 0)
+      @elements[:chromium].update_attributes(:combination_order_position => 0)
+      @elements[:manganese].update_attributes(:combination_order_position => 0)
+      @elements[:chromium].update_attributes(:combination_order_position => 0)
     }
 
     describe "NobleGas" do
@@ -81,16 +81,16 @@ describe Element do
   describe "setting positions on STI classes" do
 
     before {
-      @elements[:helium].update_attribute :combination_order_position, :first
-      @elements[:xenon].update_attribute :combination_order_position, :first
-      @elements[:argon].update_attribute :combination_order_position, :first
+      @elements[:helium].update_attributes(:combination_order_position => :first)
+      @elements[:xenon].update_attributes(:combination_order_position => :first)
+      @elements[:argon].update_attributes(:combination_order_position => :first)
 
-      @elements[:chromium].update_attribute :combination_order_position, 1
-      @elements[:manganese].update_attribute :combination_order_position, 1
-      @elements[:manganese].update_attribute :combination_order_position, 0
-      @elements[:chromium].update_attribute :combination_order_position, 0
-      @elements[:manganese].update_attribute :combination_order_position, 0
-      @elements[:chromium].update_attribute :combination_order_position, 0
+      @elements[:chromium].update_attributes(:combination_order_position => 1)
+      @elements[:manganese].update_attributes(:combination_order_position => 1)
+      @elements[:manganese].update_attributes(:combination_order_position => 0)
+      @elements[:chromium].update_attributes(:combination_order_position => 0)
+      @elements[:manganese].update_attributes(:combination_order_position => 0)
+      @elements[:chromium].update_attributes(:combination_order_position => 0)
     }
 
     describe "NobleGas" do

--- a/spec/sti-model/vehicle_spec.rb
+++ b/spec/sti-model/vehicle_spec.rb
@@ -12,7 +12,7 @@ describe Vehicle do
     }
     @vehicles.each { |name, vehicle|
       vehicle.reload
-      vehicle.update_attribute :parking_order_position, 0
+      vehicle.update_attributes(:parking_order_position => 0)
     }
     @vehicles.each {|name, vehicle| vehicle.reload }
   }
@@ -20,8 +20,8 @@ describe Vehicle do
   describe "ranking by STI parent" do
 
     before {
-      @vehicles[:volvo].update_attribute :parking_order_position, :first
-      @vehicles[:ford].update_attribute :parking_order_position, :first
+      @vehicles[:volvo].update_attributes(:parking_order_position => :first)
+      @vehicles[:ford].update_attributes(:parking_order_position => :first)
     }
 
     describe "Vehicle" do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :city
     t.integer :score
   end
+
+  create_table :musicians, :force => true do |t|
+    t.string :name
+    t.integer :performance_order
+  end
 end
 
 class Duck < ActiveRecord::Base
@@ -139,4 +144,9 @@ end
 
 class Player < ActiveRecord::Base
   # don't add rank yet, do it in the specs
+end
+
+class Musician < ActiveRecord::Base
+  include RankedModel
+  ranks :performance_order
 end


### PR DESCRIPTION
This fixes the breaking spec in #68

After I changed to `before_validation`, a bunch of specs failed. They failed only because they were using `update_attribute`, which skips validation. I replaced all uses of `update_attribute` with `update_attributes` and all tests pass again.

I think it's a little odd that setting the position is coupled with running validations. I'm not sure how to resolve that without doing ugly stuff like overriding save...
