### PR TITLE
allow writing with_same in string

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -241,6 +241,11 @@ module RankedModel
                   )
                 }
               )
+            when String
+              def interpolate(&str)
+                eval "%{#{str.call}}", str.binding
+              end
+              _finder = _finder.where(interpolate { ranker.with_same })
           end
           if !new_record?
             _finder = _finder.where \


### PR DESCRIPTION
now we can do:

``` ruby
ranks :row_order,
        with_same: 'service_id IN (SELECT id FROM services WHERE agency_id = #{instance.agency_id})'

has_one :agency, through: :service
  delegate :id, :name, to: :agency, prefix: true
```

fix issue #89 
