### PR TITLE
With position

### DIFF
--- a/Readme.mkd
+++ b/Readme.mkd
@@ -82,11 +82,11 @@ class Duck < ActiveRecord::Base
 
   ranks :row_order,           # Name this ranker, used with rank()
     :column => :sort_order    # Override the default column, which defaults to the name
-  
+
   belongs_to :pond
   ranks :swimming_order,
     :with_same => :pond_id    # Ducks belong_to Ponds, make the ranker scoped to one pond
-  
+
   scope :walking, where(:walking => true )
   ranks :walking_order,
     :scope => :walking        # Narrow this ranker to a scope
@@ -102,6 +102,12 @@ Duck.rank(:row_order)
 Pond.first.ducks.rank(:swimming_order)
 
 Duck.walking.rank(:walking)
+```
+
+If you want to serialize them with the position:
+
+``` ruby
+Duck.rank(:swimming_order).with_swimming_order_position
 ```
 
 Single Table Inheritance (STI)

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -55,6 +55,44 @@ module RankedModel
       end
 
       public "#{ranker.name}_position", "#{ranker.name}_position="
+
+      singleton_class.instance_eval do
+        define_method "with_#{ranker.name}_position" do |with_same: nil|
+          if with_same
+            instances = self.all.to_a
+            key_from_instance = case with_same
+              when Symbol
+                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model} unless self.public_instance_methods.include? with_same
+                Proc.new do |t|
+                  t.send(with_same)
+                end
+              when Array
+                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model} unless (with_same - self.public_instance_methods).empty?
+                Proc.new do |t|
+                  with_same.map { |c| t.send(c) }
+                end
+              else
+                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model}
+            end
+            indexes = {}
+
+            instances.map do |instance|
+              key = key_from_instance.call instance
+              indexes[key] ||= 0
+              instance.send("#{ranker.name}_position=", indexes[key])
+              indexes[key] += 1
+              instance
+            end
+          else
+            self.all.map.with_index do |instance, index|
+              instance.send("#{ranker.name}_position=", index)
+              instance
+            end
+          end
+        end
+
+        public "with_#{ranker.name}_position"
+      end
     end
 
   end

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -57,22 +57,18 @@ module RankedModel
       public "#{ranker.name}_position", "#{ranker.name}_position="
 
       singleton_class.instance_eval do
-        define_method "with_#{ranker.name}_position" do |with_same: ranker.with_same|
-          if with_same
+        define_method "with_#{ranker.name}_position" do
+          if ranker.with_same
             instances = self.all.to_a
-            key_from_instance = case with_same
+            key_from_instance = case ranker.with_same
               when Symbol
-                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model} unless self.public_instance_methods.include? with_same
                 Proc.new do |t|
-                  t.send(with_same)
+                  t.send(ranker.with_same)
                 end
               when Array
-                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model} unless (with_same - self.public_instance_methods).empty?
                 Proc.new do |t|
-                  with_same.map { |c| t.send(c) }
+                  ranker.with_same.map { |c| t.send(c) }
                 end
-              else
-                raise RankedModel::InvalidField, %Q{No field called "#{with_same}" found in model}
             end
             indexes = {}
 

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -57,7 +57,7 @@ module RankedModel
       public "#{ranker.name}_position", "#{ranker.name}_position="
 
       singleton_class.instance_eval do
-        define_method "with_#{ranker.name}_position" do |with_same: nil|
+        define_method "with_#{ranker.name}_position" do |with_same: ranker.with_same|
           if with_same
             instances = self.all.to_a
             key_from_instance = case with_same


### PR DESCRIPTION
This adds a class method

``` ruby
Duck.rank(:swimming_order).with_swimming_order_position
```

It is meant to be used when serializing a collection with its order. It sets the `swimming_order_position` of each item in the array. The only drawbacks are that you cannot chain queries after it (it returns an array, not an ActiveRecord object), and that it does the ordering in ruby (not SQL), and that It also won't paginate super nicely (this gem doesn't really do that anyway, so that's fine). Also, I couldn't get the tests running locally, so I didn't add any. Feel free to add some.

This should solve https://github.com/mixonic/ranked-model/issues/70, https://github.com/mixonic/ranked-model/issues/116, https://github.com/mixonic/ranked-model/issues/10