### PR TITLE
Feature - Preferred spread

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -4,12 +4,13 @@ module RankedModel
   class InvalidField < StandardError; end
 
   class Ranker
-    attr_accessor :name, :column, :scope, :with_same, :class_name, :unless
+    attr_accessor :name, :column, :scope, :with_same, :class_name, :unless, :preferred_spread
 
     def initialize name, options={}
       self.name = name.to_sym
       self.column = options[:column] || name
       self.class_name = options[:class_name]
+      self.preferred_spread = options[:preferred_spread]
 
       [ :scope, :with_same, :unless ].each do |key|
         self.send "#{key}=", options[key]
@@ -122,13 +123,21 @@ module RankedModel
         case position
           when :first, 'first'
             if current_first && current_first.rank
-              rank_at_average current_first.rank, RankedModel::MIN_RANK_VALUE
+              if ranker.preferred_spread
+                rank_with_preferred_spread current_first.rank, RankedModel::MIN_RANK_VALUE
+              else
+                rank_at_average current_first.rank, RankedModel::MIN_RANK_VALUE
+              end
             else
               position_at :middle
             end
           when :last, 'last'
             if current_last && current_last.rank
-              rank_at_average current_last.rank, RankedModel::MAX_RANK_VALUE
+              if ranker.preferred_spread
+                rank_with_preferred_spread current_last.rank, RankedModel::MAX_RANK_VALUE
+              else
+                rank_at_average current_last.rank, RankedModel::MAX_RANK_VALUE
+              end
             else
               position_at :middle
             end
@@ -164,12 +173,26 @@ module RankedModel
         end
       end
 
+      def possibly_rebalance_and_position(min, max)
+        return false unless (max - min).between?(-1, 1) # No room at the inn...
+        rebalance_ranks
+        position_at position
+        true
+      end
+
       def rank_at_average(min, max)
-        if (max - min).between?(-1, 1) # No room at the inn...
-          rebalance_ranks
-          position_at position
+        rank_at( ( ( max - min ).to_f / 2 ).ceil + min ) unless possibly_rebalance_and_position(min, max)
+      end
+
+      def rank_with_preferred_spread(min, max)
+        return if possibly_rebalance_and_position(min, max)
+
+        modifier = min < max ? 1 : -1
+
+        if (max - min).abs < ranker.preferred_spread * 2
+          rank_at(min + (max - min).abs * 0.3 * modifier)
         else
-          rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
+          rank_at(min + modifier * ranker.preferred_spread)
         end
       end
 
@@ -220,9 +243,11 @@ module RankedModel
         gaps = current_order.size + 1
         range = (RankedModel::MAX_RANK_VALUE - RankedModel::MIN_RANK_VALUE).to_f
         gap_size = (range / gaps).ceil
+        gap_size = ranker.preferred_spread if ranker.preferred_spread && gap_size > ranker.preferred_spread
+        base_position = ranker.preferred_spread ? -gap_size * ((current_order.count + 1) / 2).ceil : RankedModel::MIN_RANK_VALUE
 
         current_order.each.with_index(1) do |item, position|
-          new_rank = (gap_size * position) + RankedModel::MIN_RANK_VALUE
+          new_rank = (gap_size * position) + base_position
 
           if item.instance.id == instance.id
             rank_at new_rank

--- a/spec/duck-model/lovesick_ducks_spec.rb
+++ b/spec/duck-model/lovesick_ducks_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe LovesickDuck do
+  before {
+    @ducks = {
+      :quacky => LovesickDuck.create(:name => 'Quacky'),
+      :feathers => LovesickDuck.create(:name => 'Feathers'),
+      :wingy => LovesickDuck.create(:name => 'Wingy'),
+      :webby => LovesickDuck.create(:name => 'Webby'),
+      :waddly => LovesickDuck.create(:name => 'Waddly'),
+      :beaky => LovesickDuck.create(:name => 'Beaky')
+    }
+    @ducks.each { |name, duck|
+      duck.reload
+      duck.update :row_position => 0
+      duck.save!
+    }
+    @ducks.each {|name, duck| duck.reload }
+  }
+
+  describe "when placing duck first" do
+
+    describe "when enough room" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: i * 1000)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck keeps the right distance" do
+        expect {
+          LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :first)
+        }.to change{ @ducks[:webby].reload.row }
+
+        expect((@ducks[:webby].row - @ducks[:quacky].reload.row).abs).to be(1000)
+      end
+    end
+
+    describe "when not enough spread room" do
+
+      let(:available_room) { 1500 }
+
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MIN_RANK_VALUE + (i * 1000) + available_room)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck getting closer" do
+        LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :first)
+
+        @ducks[:webby].reload
+        @ducks[:quacky].reload
+
+        expect((@ducks[:webby].row - @ducks[:quacky].row).abs).to eq(available_room * 0.3)
+      end
+    end
+
+    describe "when rebalancing occurs" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MIN_RANK_VALUE + i)
+          @ducks[name].reload
+        end
+      }
+
+      it "all ducks spreads at a comfortable distance" do
+        LovesickDuck.find_by(id: @ducks[:beaky]).update!(row_position: :first)
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each do |name|
+          @ducks[name].reload
+        end
+
+        expect((@ducks[:beaky].row - @ducks[:quacky].row).abs).to eq(1000)
+        expect((@ducks[:feathers].row - @ducks[:wingy].row).abs).to eq(1000)
+        expect((@ducks[:webby].row - @ducks[:waddly].row).abs).to eq(1000)
+      end
+    end
+  end
+
+  describe "when placing duck last" do
+
+    describe "when enough room" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: i * 1000)
+          @ducks[name].reload
+        end
+      }
+
+      it "last duck keeps the right distance" do
+        expect {
+          LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :last)
+        }.to change{ @ducks[:webby].reload.row }
+
+        expect(@ducks[:webby].row - @ducks[:beaky].reload.row).to be(1000)
+      end
+    end
+
+    describe "when not enough spread room" do
+
+      let(:available_room) { 1500 }
+
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - (i * 1000) - available_room)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck getting closer" do
+        LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :last)
+
+        @ducks[:webby].reload
+        @ducks[:quacky].reload
+
+        expect((@ducks[:webby].row - @ducks[:quacky].row).abs).to eq(available_room * 0.3)
+      end
+    end
+
+    describe "when rebalancing occurs" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - i)
+          @ducks[name].reload
+        end
+      }
+
+      it "all ducks spreads at a comfortable distance" do
+        LovesickDuck.find_by(id: @ducks[:beaky]).update!(row_position: :last)
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each do |name|
+          @ducks[name].reload
+        end
+
+        expect((@ducks[:beaky].row - @ducks[:quacky].row).abs).to eq(1000)
+        expect((@ducks[:feathers].row - @ducks[:wingy].row).abs).to eq(1000)
+        expect((@ducks[:webby].row - @ducks[:waddly].row).abs).to eq(1000)
+      end
+    end
+  end
+end

--- a/spec/ranked-model/ranker_spec.rb
+++ b/spec/ranked-model/ranker_spec.rb
@@ -5,11 +5,12 @@ describe RankedModel::Ranker, 'initialized' do
   subject {
     RankedModel::Ranker.new \
       :overview,
-      :column     => :a_sorting_column,
-      :scope      => :a_scope,
-      :with_same  => :a_column,
-      :class_name => 'SomeClass',
-      :unless     => :a_method
+      :column           => :a_sorting_column,
+      :scope            => :a_scope,
+      :with_same        => :a_column,
+      :class_name       => 'SomeClass',
+      :unless           => :a_method,
+      :preferred_spread => 500
   }
 
   its(:name) { should == :overview }
@@ -18,6 +19,7 @@ describe RankedModel::Ranker, 'initialized' do
   its(:with_same) { should == :a_column }
   its(:class_name) { should == 'SomeClass' }
   its(:unless) { should == :a_method }
+  its(:preferred_spread) { should == 500 }
 end
 
 describe RankedModel::Ranker, 'unless as Symbol' do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -21,6 +21,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.string :pond
   end
 
+  create_table :lovesick_ducks, :force => true do |t|
+    t.string :name
+    t.integer :row
+  end
+
   create_table :wrong_scope_ducks, :force => true do |t|
     t.string :name
     t.integer :size
@@ -81,6 +86,11 @@ class Duck < ActiveRecord::Base
 
   scope :in_shin_pond, lambda { where(:pond => 'Shin') }
 
+end
+
+class LovesickDuck < ActiveRecord::Base
+  include RankedModel
+  ranks :row, :preferred_spread => 1000
 end
 
 # Negative examples


### PR DESCRIPTION
Adding an option for preferred gap size between ranked models which is being used when adding items first and last. It's also used when `rebalancing_ranks` is triggered. 

Doing it because we're using the gem together with Ember and some drag n drop. Users tend to drag a lot of items to the top (`:first`). We want to avoid collisions as much as possible, cause when we're touching other models than the one being updated, the data is no longer synced between front and backend.

Do whatever you want with this PR, just throwing it out there.