### PR TITLE
Fix unbounded query when giving position :last

### DIFF
--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -294,9 +294,7 @@ module RankedModel
 
       def current_last
         @current_last ||= begin
-          if (ordered_instance = finder.
-                                   reverse.
-                                   first)
+          if (ordered_instance = finder.last)
             RankedModel::Ranker::Mapper.new ranker, ordered_instance
           end
         end


### PR DESCRIPTION
### The Problem
I noticed that when an item is updated or created with a position of `:last`, an unbounded query is made to find the current `last` record in the group. I tracked it down to `#current_last`, whichcalls `finder.reverse.first`.

Since [Rails delegates `#reverse` to `#records`](https://github.com/rails/rails/blob/ab3c1c6e5ee3e995661b75e12d8de801f682cd7f/activerecord/lib/active_record/relation/delegation.rb#L88-L91), this ends up being equivalent to `finder.records.reverse.first`, which makes the unbounded query.

### Proposed Fix
Changing `finder.reverse.first`. to `finder.last` has the same effect but without the unbounded query.

I'm not sure there any additional tests to write--I could perhaps see adding one that asserts `#records` is not called. 

Thanks for your attention, and for your work on this great gem!