### PR TITLE
Remove NonNilColumnDefault exception from ranked-model.rb

### DIFF
--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -49,7 +49,7 @@ module RankedModel
       ranker = RankedModel::Ranker.new(*args)
 
       if column_default(ranker)
-        Rails.logger.fatal NonNilColumnDefault, %Q{Your ranked model column "#{ranker.name}" must not have a default value in the database.}
+        Rails.logger.fatal %Q{NonNilColumnDefault:  Your ranked model column "#{ranker.name}" must not have a default value in the database.}
       end
 
       self.rankers << ranker

--- a/lib/ranked-model.rb
+++ b/lib/ranked-model.rb
@@ -49,7 +49,7 @@ module RankedModel
       ranker = RankedModel::Ranker.new(*args)
 
       if column_default(ranker)
-        raise NonNilColumnDefault, %Q{Your ranked model column "#{ranker.name}" must not have a default value in the database.}
+        Rails.logger.fatal NonNilColumnDefault, %Q{Your ranked model column "#{ranker.name}" must not have a default value in the database.}
       end
 
       self.rankers << ranker


### PR DESCRIPTION
For your consideration...

Raising the NonNilColumnDefault exception causes the Rails app to not even boot.  Allow users to react to this requirement without crashing their application after adding the gem.