### PR TITLE
Feature: Customize spread to maintain bigger emptiness in the rank ends.

### DIFF
--- a/spec/duck-model/lovesick_ducks_spec.rb
+++ b/spec/duck-model/lovesick_ducks_spec.rb
@@ -20,6 +20,19 @@ describe LovesickDuck do
 
   describe "when placing duck first" do
 
+    context "in large numbers" do
+      let!(:lovesick_ducks) { 200.times.map { LovesickDuck.create(name: "LovesickDuck #{_1 + 1}", row: :first) } }
+
+      it "evenly spaces them" do
+        expect(lovesick_ducks.pluck(:row).each_cons(2).map { _2 - _1 }).to all(eq 1000)
+      end
+
+      it "didn't rebalance them" do
+        expect { lovesick_ducks.each(&:reload) }
+          .not_to change { lovesick_ducks.pluck(:row) }
+      end
+    end
+
     describe "when enough room" do
       before {
         [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
@@ -80,6 +93,19 @@ describe LovesickDuck do
   end
 
   describe "when placing duck last" do
+
+    context "in large numbers" do
+      let!(:lovesick_ducks) { 200.times.map { LovesickDuck.create(name: "LovesickDuck #{_1 + 1}", row: :last) } }
+
+      it "evenly spaces them" do
+        expect(lovesick_ducks.pluck(:row).each_cons(2).map { _2 - _1 }).to all(eq 1000)
+      end
+
+      it "didn't rebalance them" do
+        expect { lovesick_ducks.each(&:reload) }
+          .not_to change { lovesick_ducks.pluck(:row) }
+      end
+    end
 
     describe "when enough room" do
       before {

--- a/spec/duck-model/lovesick_ducks_spec.rb
+++ b/spec/duck-model/lovesick_ducks_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe LovesickDuck do
+  before {
+    @ducks = {
+      :quacky => LovesickDuck.create(:name => 'Quacky'),
+      :feathers => LovesickDuck.create(:name => 'Feathers'),
+      :wingy => LovesickDuck.create(:name => 'Wingy'),
+      :webby => LovesickDuck.create(:name => 'Webby'),
+      :waddly => LovesickDuck.create(:name => 'Waddly'),
+      :beaky => LovesickDuck.create(:name => 'Beaky')
+    }
+    @ducks.each { |name, duck|
+      duck.reload
+      duck.update :row_position => 0
+      duck.save!
+    }
+    @ducks.each {|name, duck| duck.reload }
+  }
+
+  describe "when placing duck first" do
+
+    describe "when enough room" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: i * 1000)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck keeps the right distance" do
+        expect {
+          LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :first)
+        }.to change{ @ducks[:webby].reload.row }
+
+        expect((@ducks[:webby].row - @ducks[:quacky].reload.row).abs).to be(1000)
+      end
+    end
+
+    describe "when not enough spread room" do
+
+      let(:available_room) { 1500 }
+
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MIN_RANK_VALUE + (i * 1000) + available_room)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck getting closer" do
+        LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :first)
+
+        @ducks[:webby].reload
+        @ducks[:quacky].reload
+
+        expect((@ducks[:webby].row - @ducks[:quacky].row).abs).to eq(available_room * 0.3)
+      end
+    end
+
+    describe "when rebalancing occurs" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MIN_RANK_VALUE + i)
+          @ducks[name].reload
+        end
+      }
+
+      it "all ducks spreads at a comfortable distance" do
+        LovesickDuck.find_by(id: @ducks[:beaky]).update!(row_position: :first)
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each do |name|
+          @ducks[name].reload
+        end
+
+        expect((@ducks[:beaky].row - @ducks[:quacky].row).abs).to eq(1000)
+        expect((@ducks[:feathers].row - @ducks[:wingy].row).abs).to eq(1000)
+        expect((@ducks[:webby].row - @ducks[:waddly].row).abs).to eq(1000)
+      end
+    end
+  end
+
+  describe "when placing duck last" do
+
+    describe "when enough room" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: i * 1000)
+          @ducks[name].reload
+        end
+      }
+
+      it "last duck keeps the right distance" do
+        expect {
+          LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :last)
+        }.to change{ @ducks[:webby].reload.row }
+
+        expect(@ducks[:webby].row - @ducks[:beaky].reload.row).to be(1000)
+      end
+    end
+
+    describe "when not enough spread room" do
+
+      let(:available_room) { 1500 }
+
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - (i * 1000) - available_room)
+          @ducks[name].reload
+        end
+      }
+
+      it "first duck getting closer" do
+        LovesickDuck.find_by(id: @ducks[:webby]).update!(row_position: :last)
+
+        @ducks[:webby].reload
+        @ducks[:quacky].reload
+
+        expect((@ducks[:webby].row - @ducks[:quacky].row).abs).to eq(available_room * 0.3)
+      end
+    end
+
+    describe "when rebalancing occurs" do
+      before {
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each_with_index do |name, i|
+          LovesickDuck.where(id: @ducks[name].id).update_all(row: RankedModel::MAX_RANK_VALUE - i)
+          @ducks[name].reload
+        end
+      }
+
+      it "all ducks spreads at a comfortable distance" do
+        LovesickDuck.find_by(id: @ducks[:beaky]).update!(row_position: :last)
+        [:quacky, :feathers, :wingy, :webby, :waddly, :beaky].each do |name|
+          @ducks[name].reload
+        end
+
+        expect((@ducks[:beaky].row - @ducks[:quacky].row).abs).to eq(1000)
+        expect((@ducks[:feathers].row - @ducks[:wingy].row).abs).to eq(1000)
+        expect((@ducks[:webby].row - @ducks[:waddly].row).abs).to eq(1000)
+      end
+    end
+  end
+end

--- a/spec/ranked-model/ranker_spec.rb
+++ b/spec/ranked-model/ranker_spec.rb
@@ -5,11 +5,12 @@ describe RankedModel::Ranker, 'initialized' do
   subject {
     RankedModel::Ranker.new \
       :overview,
-      :column     => :a_sorting_column,
-      :scope      => :a_scope,
-      :with_same  => :a_column,
-      :class_name => 'SomeClass',
-      :unless     => :a_method
+      :column           => :a_sorting_column,
+      :scope            => :a_scope,
+      :with_same        => :a_column,
+      :class_name       => 'SomeClass',
+      :unless           => :a_method,
+      :preferred_spread => 500
   }
 
   its(:name) { should == :overview }
@@ -18,6 +19,7 @@ describe RankedModel::Ranker, 'initialized' do
   its(:with_same) { should == :a_column }
   its(:class_name) { should == 'SomeClass' }
   its(:unless) { should == :a_method }
+  its(:preferred_spread) { should == 500 }
 end
 
 describe RankedModel::Ranker, 'unless as Symbol' do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -23,6 +23,11 @@ ActiveRecord::Schema.define :version => 0 do
 
   add_index :ducks, [:landing_order, :lake_id, :flock_id], unique: true
 
+  create_table :lovesick_ducks, :force => true do |t|
+    t.string :name
+    t.integer :row
+  end
+
   create_table :wrong_scope_ducks, :force => true do |t|
     t.string :name
     t.integer :size
@@ -83,6 +88,11 @@ class Duck < ActiveRecord::Base
 
   scope :in_shin_pond, lambda { where(:pond => 'Shin') }
 
+end
+
+class LovesickDuck < ActiveRecord::Base
+  include RankedModel
+  ranks :row, :preferred_spread => 1000
 end
 
 # Negative examples


### PR DESCRIPTION
Co-authored-by: Frysch [anders.fryksborn@gmail.com](mailto:anders.fryksborn@gmail.com)
Co-authored-by: Caleb Buxton [caleb.buxton@babylist.com](mailto:caleb.buxton@babylist.com)

Rebases the preferred_spread Feature atop of the latest:
- https://github.com/brendon/ranked-model/pull/161

## Requesting Clarification:

> I'm still totally keen to solve this problem. Equal spacing really doesn't work when things are always appended to the end of the list. It's an exponential problem by the looks. The list can only be folded so many times before running out of accuracy. I still like the idea of using some kind of sub-spacing per my message above, but I get a gut feeling this might also suffer from the same problem eventually but it certainly won't cause problems with appending where list items don't often get shuffled.
>
> - [@brendon commented on Oct 4, 2020](https://github.com/brendon/ranked-model/pull/161#issuecomment-703325193)

I've added test coverage that [illustrates rebalancing during adds](https://github.com/brendon/ranked-model/pull/195/commits/d41d4bcdfe8ddf9453e169bfd053b05be0064bac).

This is an opt-in feature, so there isn't impact on the cases the original implementation is optimized for … which is to say: very few additions, and quite a lot of reordering.

While the maximum integer available in MySQL is a rather large number, its `log2` isn't. The strategy provided by @frysch supports flexible allocation of the MySQL maximum integer space, so users can tune it to their use case.