### PR TITLE
Publish ActiveSupport notifications on rebalancing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.4
           - 2.5
           - 2.6
           - 2.7
@@ -28,12 +27,6 @@ jobs:
           - mysql
           - postgresql
         exclude:
-          - ruby: 2.4
-            gemfile: gemfiles/rails_6_0.gemfile
-          - ruby: 2.4
-            gemfile: gemfiles/rails_6_1.gemfile
-          - ruby: 2.4
-            gemfile: gemfiles/rails_7_0.gemfile
           - ruby: 2.5
             gemfile: gemfiles/rails_7_0.gemfile
           - ruby: 2.6

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -273,8 +273,8 @@ Record updates to rebalance ranks do not trigger ActiveRecord callbacks. If you 
 (to index them in a secondary data store, for example), you can subscribe to the `ranked_model.ranks_updated`
 [ActiveSupport notification](https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Notifications.html).
 Subscribed consumers receive an event for each rearrangement or rebalancing, the payload of which includes the
-triggering instance and the scope and with_same options for the ranking, which can be used to retrieve the affected
-records.
+triggering instance and the `scope` and `with_same` options for the ranking, which can be used to retrieve the
+affected records.
 
 ```ruby
 ActiveSupport::Notifications.subscribe("ranked_model.ranks_updated") do |_name, _start, _finish, _id, payload|

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -269,6 +269,21 @@ this occurs, ranked-model will try to shift other records out of the way. If ite
 shifted anymore, it will rebalance the distribution of rank numbers across all members
 of the ranked group.
 
+Record updates to rebalance ranks do not trigger ActiveRecord callbacks. If you need to react to these updates
+(to index them in a secondary data store, for example), you can subscribe to the `ranked_model.ranks_updated`
+[ActiveSupport notification](https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Notifications.html).
+Subscribed consumers receive an event for each rearrangement or rebalancing, the payload of which includes the
+triggering instance and the scope and with_same options for the ranking, which can be used to retrieve the affected
+records.
+
+```ruby
+ActiveSupport::Notifications.subscribe("ranked_model.ranks_updated") do |_name, _start, _finish, _id, payload|
+  # payload[:instance] - the instance whose update triggered the rebalance
+  # payload[:scope] - the scope applied to the ranking
+  # payload[:with_same] - the with_same option applied to the ranking
+end
+```
+
 Contributing
 ------------
 

--- a/lib/ranked-model/ranker.rb
+++ b/lib/ranked-model/ranker.rb
@@ -173,7 +173,7 @@ module RankedModel
 
       def rank_at_average(min, max)
         if (max - min).between?(-1, 1) # No room at the inn...
-          rebalance_ranks
+          notify_ranks_updated { rebalance_ranks }
           position_at position
         else
           rank_at( ( ( max - min ).to_f / 2 ).ceil + min )
@@ -183,7 +183,7 @@ module RankedModel
       def assure_unique_position
         if ( new_record? || rank_changed? )
           if (rank > RankedModel::MAX_RANK_VALUE) || rank_taken?
-            rearrange_ranks
+            notify_ranks_updated { rearrange_ranks }
           end
         end
       end
@@ -350,6 +350,16 @@ module RankedModel
         end
       end
 
+      def notify_ranks_updated(&block)
+        ActiveSupport::Notifications.instrument(
+          "ranked_model.ranks_updated",
+          instance: instance,
+          scope: ranker.scope,
+          with_same: ranker.with_same
+        ) do
+          block.call
+        end
+      end
     end
 
   end

--- a/spec/notifications_spec.rb
+++ b/spec/notifications_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+describe "notifications" do
+  before do
+    @notifications_count = 0
+    @notification_payloads = []
+
+    ActiveSupport::Notifications.subscribe("ranked_model.ranks_updated") do |name, start, finish, id, payload|
+      @notifications_count += 1
+      @notification_payloads << payload
+    end
+  end
+
+  after do
+    ActiveSupport::Notifications.unsubscribe("ranked_model.ranks_updated")
+  end
+
+  context "when rearranging" do
+    it "notifies subscribers with the instance" do
+      Number.create(order: RankedModel::MAX_RANK_VALUE)
+      second_number = Number.create(order: RankedModel::MAX_RANK_VALUE)
+
+      expect(@notifications_count).to eq(1)
+      expect(@notification_payloads.last[:instance]).to eq(second_number)
+    end
+
+    context "with scope" do
+      it "notifies subscribers with the instance and scope" do
+        Duck.create(size: RankedModel::MAX_RANK_VALUE, pond: "Shin")
+        second_duck = Duck.create(size: RankedModel::MAX_RANK_VALUE, pond: "Shin")
+
+        expect(@notifications_count).to eq(1)
+        expect(@notification_payloads.last[:instance]).to eq(second_duck)
+        expect(@notification_payloads.last[:scope]).to eq(:in_shin_pond)
+      end
+    end
+
+    context "with with_same" do
+      it "notifies subscribers with the instance and with_same" do
+        Duck.create(age: RankedModel::MAX_RANK_VALUE, pond: "Shin")
+        second_duck = Duck.create(age: RankedModel::MAX_RANK_VALUE, pond: "Shin")
+
+        expect(@notifications_count).to eq(1)
+        expect(@notification_payloads.last[:instance]).to eq(second_duck)
+        expect(@notification_payloads.last[:with_same]).to eq(:pond)
+      end
+    end
+  end
+
+  context "when rebalancing" do
+    it "notifies subscribers with the instance" do
+      31.times { Number.create }
+      thirty_second_number = Number.create
+
+      expect(@notifications_count).to eq(1)
+      expect(@notification_payloads.last[:instance]).to eq(thirty_second_number)
+    end
+
+    context "with scope" do
+      it "notifies subscribers with the instance and scope" do
+        31.times { Duck.create(pond: "Shin") }
+        thirty_second_duck = Duck.create(pond: "Shin")
+
+        expect(@notifications_count).to eq(4) # Duck has four ranks
+        expect(@notification_payloads.last[:instance]).to eq(thirty_second_duck)
+        expect(@notification_payloads.map { |p| p[:scope] }).to include(:in_shin_pond)
+      end
+    end
+
+    context "with with_same" do
+      it "notifies subscribers with the instance and with_same" do
+        31.times { Duck.create(pond: "Shin") }
+        thirty_second_duck = Duck.create(pond: "Shin")
+
+        expect(@notifications_count).to eq(4)
+        expect(@notification_payloads.last[:instance]).to eq(thirty_second_duck)
+        expect(@notification_payloads.map { |p| p[:with_same] }).to include(:pond)
+      end
+    end
+  end
+
+  context "when not rearranging or rebalancing" do
+    it "does not notify subscribers" do
+      Number.create
+
+      expect(@notifications_count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Record updates to rebalance ranks do not trigger ActiveRecord callbacks. This makes it difficult to react to these updates (for example, to index them in a secondary data store). This commit instruments the updates with ActiveSupport notifications. Subscribed consumers receive an event for each rearrangement or rebalancing, the payload of which includes the triggering instance and the `scope` and `with_same` options for the ranking, which can be used to retrieve the affected records.

Addresses #202.